### PR TITLE
Remove libgstcompositor.so

### DIFF
--- a/gstreamer1-plugins-bad.spec
+++ b/gstreamer1-plugins-bad.spec
@@ -397,7 +397,6 @@ find %{buildroot} -name '*.la' -delete
 %{_libdir}/gstreamer-%{majorminor}/libgstchromaprint.so
 %{_libdir}/gstreamer-%{majorminor}/libgstcoloreffects.so
 %{_libdir}/gstreamer-%{majorminor}/libgstcolormanagement.so
-%{_libdir}/gstreamer-%{majorminor}/libgstcompositor.so
 %{_libdir}/gstreamer-%{majorminor}/libgstcurl.so
 %{_libdir}/gstreamer-%{majorminor}/libgstdashdemux.so
 %{_libdir}/gstreamer-%{majorminor}/libgstdc1394.so


### PR DESCRIPTION
This library fails the upgrade to Fedora 30 because it is included in gstreamer1-plugins-base.
I tried to build the package for Fedora 30 but did not manage to get all dependencies so I did not test it.